### PR TITLE
Adds `Sentinel` node type

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Many of the original library types are implemented, including:
 - Map(2,3,4,If,N)
 - Observe
 - Return
+- Sentinel
 - Var
 - Watch
 

--- a/examples/blaze/main.go
+++ b/examples/blaze/main.go
@@ -32,14 +32,12 @@ func main() {
 			{Name: "pkg/engine", DependsOn: []string{"pkg/config", "pkg/util"}},
 			{Name: "pkg/util"},
 		},
-		OnUpdate: func(_ context.Context, d incrutil.Dependency) {
-			fmt.Printf("built: %s\n", d.Name)
-		},
 		Action: func(ctx context.Context, d incrutil.Dependency) (BuildResult, error) {
 			start := time.Now()
 			var delay = time.Duration(250 + rand.Intn(1500))
 			<-time.After(delay * time.Millisecond)
 			elapsed := time.Since(start)
+			fmt.Printf("built: %s\n", d.Name)
 			return BuildResult{
 				Package: d.Name,
 				Elapsed: elapsed,

--- a/graph.go
+++ b/graph.go
@@ -524,7 +524,6 @@ func (graph *Graph) watchNode(sn ISentinel, input INode) error {
 	graph.addSentinel(sn)
 	wasNecsesary := input.Node().isNecessary()
 	input.Node().addSentinels(sn)
-	sn.Node().addWatched(input)
 	graph.link(input, sn)
 	if !wasNecsesary {
 		if err := graph.becameNecessary(input); err != nil {
@@ -535,7 +534,6 @@ func (graph *Graph) watchNode(sn ISentinel, input INode) error {
 		return err
 	}
 	graph.recomputeHeap.addIfNotPresent(sn)
-
 	graph.handleAfterStabilizationMu.Lock()
 	graph.handleAfterStabilization[sn.Node().id] = sn.Node().onUpdateHandlers
 	graph.handleAfterStabilizationMu.Unlock()
@@ -551,7 +549,6 @@ func (graph *Graph) unobserveNode(o IObserver, input INode) {
 func (graph *Graph) unwatchNode(sn ISentinel, input INode) {
 	graph.removeSentinel(sn)
 	input.Node().removeSentinel(sn.Node().id)
-	sn.Node().removeWatched(input.Node().id)
 	graph.unlink(input, sn)
 	graph.checkIfUnnecessary(input)
 }

--- a/graph.go
+++ b/graph.go
@@ -552,6 +552,7 @@ func (graph *Graph) unwatchNode(sn ISentinel, input INode) {
 	graph.removeSentinel(sn)
 	input.Node().removeSentinel(sn.Node().id)
 	sn.Node().removeWatched(input.Node().id)
+	graph.unlink(input, sn)
 	graph.checkIfUnnecessary(input)
 }
 

--- a/graph.go
+++ b/graph.go
@@ -551,6 +551,7 @@ func (graph *Graph) unobserveNode(o IObserver, input INode) {
 func (graph *Graph) unwatchNode(sn ISentinel, input INode) {
 	graph.removeSentinel(sn)
 	input.Node().removeSentinel(sn.Node().id)
+	sn.Node().removeWatched(input.Node().id)
 	graph.checkIfUnnecessary(input)
 }
 

--- a/incrutil/dependency_graph_test.go
+++ b/incrutil/dependency_graph_test.go
@@ -14,6 +14,8 @@ func Test_DependencyGraph(t *testing.T) {
 	var actionedMu sync.Mutex
 	actioned := make(map[string]int)
 
+	stale := []string{}
+
 	dg := DependencyGraph[string]{
 		Dependencies: []Dependency{
 			{Name: "cmd/blazectl", DependsOn: []string{"pkg/config", "pkg/engine", "pkg/util"}},
@@ -27,6 +29,14 @@ func Test_DependencyGraph(t *testing.T) {
 			actioned[d.Name]++
 			actionedMu.Unlock()
 			return "ok!", nil
+		},
+		CheckIfStale: func(_ context.Context, d Dependency) (bool, error) {
+			for _, s := range stale {
+				if s == d.Name {
+					return true, nil
+				}
+			}
+			return false, nil
 		},
 	}
 
@@ -49,7 +59,7 @@ func Test_DependencyGraph(t *testing.T) {
 	testutil.Equal(t, 1, actioned["pkg/engine"])
 	testutil.Equal(t, 1, actioned["pkg/util"])
 
-	graph.SetStale(nodes["pkg/engine"])
+	stale = []string{"pkg/engine"}
 
 	err = graph.ParallelStabilize(ctx)
 	testutil.NoError(t, err)
@@ -59,4 +69,50 @@ func Test_DependencyGraph(t *testing.T) {
 	testutil.Equal(t, 1, actioned["pkg/config"])
 	testutil.Equal(t, 2, actioned["pkg/engine"])
 	testutil.Equal(t, 1, actioned["pkg/util"])
+}
+
+func Test_DependencyGraph_duplicateDependencyName(t *testing.T) {
+	ctx := testContext()
+
+	dg := DependencyGraph[string]{
+		Dependencies: []Dependency{
+			{Name: "cmd/blazectl", DependsOn: []string{"pkg/config", "pkg/engine", "pkg/util"}},
+			{Name: "cmd/blazectl", DependsOn: []string{"pkg/config", "pkg/engine", "pkg/util"}},
+			{Name: "pkg/config", DependsOn: []string{"pkg/util"}},
+			{Name: "pkg/engine", DependsOn: []string{"pkg/config", "pkg/util"}},
+			{Name: "pkg/util"},
+		},
+		Action: func(ctx context.Context, d Dependency) (string, error) {
+			return "ok!", nil
+		},
+	}
+
+	graph, nodes, err := dg.Create(ctx)
+	testutil.Error(t, err)
+	testutil.Equal(t, `dependency graph; duplicate dependency "cmd/blazectl"`, err.Error())
+	testutil.Nil(t, graph)
+	testutil.Equal(t, 0, len(nodes))
+}
+
+func Test_DependencyGraph_missingDependency(t *testing.T) {
+	ctx := testContext()
+
+	dg := DependencyGraph[string]{
+		Dependencies: []Dependency{
+			{Name: "cmd/blazectl", DependsOn: []string{"pkg/config", "pkg/engine", "pkg/util"}},
+			{Name: "cmd/blazesrv", DependsOn: []string{"pkg/config", "not-a-thing", "pkg/util"}},
+			{Name: "pkg/config", DependsOn: []string{"pkg/util"}},
+			{Name: "pkg/engine", DependsOn: []string{"pkg/config", "pkg/util"}},
+			{Name: "pkg/util"},
+		},
+		Action: func(ctx context.Context, d Dependency) (string, error) {
+			return "ok!", nil
+		},
+	}
+
+	graph, nodes, err := dg.Create(ctx)
+	testutil.Error(t, err)
+	testutil.Equal(t, `dependency graph; dependency "cmd/blazesrv" names non-existent dependency "not-a-thing"`, err.Error())
+	testutil.Nil(t, graph)
+	testutil.Equal(t, 0, len(nodes))
 }

--- a/incrutil/dependency_graph_test.go
+++ b/incrutil/dependency_graph_test.go
@@ -1,0 +1,62 @@
+package incrutil
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/wcharczuk/go-incr/testutil"
+)
+
+func Test_DependencyGraph(t *testing.T) {
+	ctx := testContext()
+
+	var actionedMu sync.Mutex
+	actioned := make(map[string]int)
+
+	dg := DependencyGraph[string]{
+		Dependencies: []Dependency{
+			{Name: "cmd/blazectl", DependsOn: []string{"pkg/config", "pkg/engine", "pkg/util"}},
+			{Name: "cmd/blazesrv", DependsOn: []string{"pkg/config", "pkg/engine", "pkg/util"}},
+			{Name: "pkg/config", DependsOn: []string{"pkg/util"}},
+			{Name: "pkg/engine", DependsOn: []string{"pkg/config", "pkg/util"}},
+			{Name: "pkg/util"},
+		},
+		Action: func(ctx context.Context, d Dependency) (string, error) {
+			actionedMu.Lock()
+			actioned[d.Name]++
+			actionedMu.Unlock()
+			return "ok!", nil
+		},
+	}
+
+	graph, nodes, err := dg.Create(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, 5, len(nodes))
+
+	testutil.Equal(t, 0, actioned["cmd/blazectl"])
+	testutil.Equal(t, 0, actioned["cmd/blazesrv"])
+	testutil.Equal(t, 0, actioned["pkg/config"])
+	testutil.Equal(t, 0, actioned["pkg/engine"])
+	testutil.Equal(t, 0, actioned["pkg/util"])
+
+	err = graph.ParallelStabilize(ctx)
+	testutil.NoError(t, err)
+
+	testutil.Equal(t, 1, actioned["cmd/blazectl"])
+	testutil.Equal(t, 1, actioned["cmd/blazesrv"])
+	testutil.Equal(t, 1, actioned["pkg/config"])
+	testutil.Equal(t, 1, actioned["pkg/engine"])
+	testutil.Equal(t, 1, actioned["pkg/util"])
+
+	graph.SetStale(nodes["pkg/engine"])
+
+	err = graph.ParallelStabilize(ctx)
+	testutil.NoError(t, err)
+
+	testutil.Equal(t, 2, actioned["cmd/blazectl"])
+	testutil.Equal(t, 2, actioned["cmd/blazesrv"])
+	testutil.Equal(t, 1, actioned["pkg/config"])
+	testutil.Equal(t, 2, actioned["pkg/engine"])
+	testutil.Equal(t, 1, actioned["pkg/util"])
+}

--- a/node.go
+++ b/node.go
@@ -44,6 +44,11 @@ type Node struct {
 	// observers are observer nodes that are attached to this
 	// node or its children.
 	observers []IObserver
+	// observers are observer nodes that are attached to this
+	// node or its children.
+	sentinels []ISentinel
+	// watched are nodes that a sentinel could be watching
+	watched []INode
 	// valid indicates if the scope that created the node is itself valid
 	valid bool
 	// forceNecessary forces the necessary state on the node
@@ -198,6 +203,14 @@ func (n *Node) addObservers(observers ...IObserver) {
 	n.observers = append(n.observers, observers...)
 }
 
+func (n *Node) addSentinels(sentinels ...ISentinel) {
+	n.sentinels = append(n.sentinels, sentinels...)
+}
+
+func (n *Node) addWatched(watched ...INode) {
+	n.watched = append(n.watched, watched...)
+}
+
 func (n *Node) removeChild(id Identifier) {
 	n.children = remove(n.children, id)
 }
@@ -208,6 +221,14 @@ func (n *Node) removeParent(id Identifier) {
 
 func (n *Node) removeObserver(id Identifier) {
 	n.observers = remove(n.observers, id)
+}
+
+func (n *Node) removeSentinel(id Identifier) {
+	n.sentinels = remove(n.sentinels, id)
+}
+
+func (n *Node) removeWatched(id Identifier) {
+	n.watched = remove(n.watched, id)
 }
 
 // maybeCutoff calls the cutoff delegate if it's set, otherwise
@@ -302,7 +323,7 @@ func (n *Node) nodeParents() []INode {
 }
 
 func (n *Node) isStaleInRespectToParent() (stale bool) {
-	for _, p := range n.nodeParents() {
+	for _, p := range n.parents {
 		if p.Node().changedAt > n.recomputedAt {
 			stale = true
 			return
@@ -328,5 +349,5 @@ func (n *Node) isNecessary() bool {
 	if n.forceNecessary {
 		return true
 	}
-	return len(n.children) > 0 || len(n.observers) > 0
+	return len(n.children) > 0 || len(n.observers) > 0 || len(n.sentinels) > 0
 }

--- a/node.go
+++ b/node.go
@@ -47,8 +47,6 @@ type Node struct {
 	// observers are observer nodes that are attached to this
 	// node or its children.
 	sentinels []ISentinel
-	// watched are nodes that a sentinel could be watching
-	watched []INode
 	// valid indicates if the scope that created the node is itself valid
 	valid bool
 	// forceNecessary forces the necessary state on the node
@@ -207,10 +205,6 @@ func (n *Node) addSentinels(sentinels ...ISentinel) {
 	n.sentinels = append(n.sentinels, sentinels...)
 }
 
-func (n *Node) addWatched(watched ...INode) {
-	n.watched = append(n.watched, watched...)
-}
-
 func (n *Node) removeChild(id Identifier) {
 	n.children = remove(n.children, id)
 }
@@ -225,10 +219,6 @@ func (n *Node) removeObserver(id Identifier) {
 
 func (n *Node) removeSentinel(id Identifier) {
 	n.sentinels = remove(n.sentinels, id)
-}
-
-func (n *Node) removeWatched(id Identifier) {
-	n.watched = remove(n.watched, id)
 }
 
 // maybeCutoff calls the cutoff delegate if it's set, otherwise

--- a/scope.go
+++ b/scope.go
@@ -24,6 +24,11 @@ func WithinScope[A INode](scope Scope, node A) A {
 	return node
 }
 
+// GraphForScope returns the graph for a given scope.
+func GraphForScope(s Scope) *Graph {
+	return s.scopeGraph()
+}
+
 // GraphForNode returns the graph for a given node as derrived through
 // the scope it was created in, which must return a graph reference.
 func GraphForNode(node INode) *Graph {

--- a/sentinel.go
+++ b/sentinel.go
@@ -1,0 +1,89 @@
+package incr
+
+import "context"
+
+// Sentinel returns a node that always evaluates a cutoff function for each stabilization.
+//
+// You can attach sentinels to parts of a graph to automatically recompute nodes
+// on the result of a function withouth having to mark those nodes explicitly stale.
+//
+// As a result, sentinels are somewhat expensive, and should only be used in situations
+// where you know the function will return true rarely.
+//
+// The provided function should return `true` if we should recompute watched nodes, and
+// returning `false` will stop recomputation from propagating past this node.
+//
+// The `watched` variadic list of nodes are the nodes that will be recomputed if the provided
+// function returns true. The watched node list is associated as children, but because the sentinel
+// has no value, the nodes existing parent values are passed to them as normal.
+func Sentinel(scope Scope, fn func() bool, watched ...INode) SentinelIncr {
+	return SentinelContext(scope, func(_ context.Context) (bool, error) {
+		return fn(), nil
+	}, watched...)
+}
+
+// SentinelContext returns a node that always evaluates a context cutoff function for each stabilization.
+//
+// You can attach sentinels to parts of a graph to automatically recompute nodes
+// on the result of a function withouth having to mark those nodes explicitly stale.
+//
+// As a result, sentinels are somewhat expensive, and should only be used in situations
+// where you know the function will return true rarely.
+//
+// The provided function should return `true` if we should recompute watched nodes, and
+// returning `false` will stop recomputation from propagating past this node. If the provided function
+// returns an error, the stabilization is stopped and depending on if the stabilization is parallel or serial
+// the error will be returned after the height block is completed, or immediately respectively.
+//
+// The `watched` variadic list of nodes are the nodes that will be recomputed if the provided
+// function returns true. The watched node list is associated as children, but because the sentinel
+// has no value, the nodes existing parent values are passed to them as normal.
+func SentinelContext(scope Scope, fn func(context.Context) (bool, error), watched ...INode) SentinelIncr {
+	s := WithinScope(scope, &sentinelIncr{
+		n:  NewNode("sentinel"),
+		fn: fn,
+	})
+	graph := scope.scopeGraph()
+	for _, w := range watched {
+		_ = graph.watchNode(s, w)
+	}
+	return s
+}
+
+// SentinelIncr is a node that is recomputed always, but can cutoff
+// the computation based on the result of a provided deligate.
+type SentinelIncr interface {
+	IAlways
+	ICutoff
+	IStale
+	ISentinel
+}
+
+// ISentinel is a node that always cutsoff and has no children.
+type ISentinel interface {
+	INode
+	Unwatch(context.Context)
+}
+
+type sentinelIncr struct {
+	n       *Node
+	fn      func(context.Context) (bool, error)
+	watched []INode
+}
+
+func (s *sentinelIncr) Node() *Node { return s.n }
+
+func (s *sentinelIncr) Always() {}
+
+func (s *sentinelIncr) Stale() bool { return true }
+
+func (s *sentinelIncr) Cutoff(ctx context.Context) (bool, error) {
+	isStale, err := s.fn(ctx)
+	return !isStale, err
+}
+
+func (s *sentinelIncr) Unwatch(_ context.Context) {
+	for _, w := range s.watched {
+		GraphForNode(s).unwatchNode(s, w)
+	}
+}

--- a/sentinel.go
+++ b/sentinel.go
@@ -40,8 +40,9 @@ func Sentinel(scope Scope, fn func() bool, watched ...INode) SentinelIncr {
 // has no value, the nodes existing parent values are passed to them as normal.
 func SentinelContext(scope Scope, fn func(context.Context) (bool, error), watched ...INode) SentinelIncr {
 	s := WithinScope(scope, &sentinelIncr{
-		n:  NewNode("sentinel"),
-		fn: fn,
+		n:       NewNode("sentinel"),
+		fn:      fn,
+		watched: watched,
 	})
 	graph := scope.scopeGraph()
 	for _, w := range watched {

--- a/sentinel.go
+++ b/sentinel.go
@@ -84,7 +84,8 @@ func (s *sentinelIncr) Cutoff(ctx context.Context) (bool, error) {
 }
 
 func (s *sentinelIncr) Unwatch(_ context.Context) {
+	graph := s.n.createdIn.scopeGraph()
 	for _, w := range s.watched {
-		GraphForNode(s).unwatchNode(s, w)
+		graph.unwatchNode(s, w)
 	}
 }

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -78,3 +78,53 @@ func Test_Sentinel_Unwatch(t *testing.T) {
 
 	testutil.Equal(t, 2, updates)
 }
+
+func Test_Sentinel_withinBind(t *testing.T) {
+	ctx := testContext()
+	g := New()
+
+	v := Var(g, "foo")
+	var updates int
+	m := Map(g, v, func(vv string) string {
+		updates++
+		return vv + fmt.Sprintf("-mapped-%d", updates)
+	})
+	_ = Sentinel(g, func() bool {
+		return updates < 3
+	}, m)
+
+	bv := Var(g, "a")
+	b := Bind(g, bv, func(bs Scope, which string) Incr[string] {
+		if which == "a" {
+			return m
+		}
+		return Return(bs, "nope")
+	})
+	ob := MustObserve(g, b)
+
+	err := g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-1", ob.Value())
+
+	err = g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-2", ob.Value())
+
+	bv.Set("b")
+
+	err = g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "nope", ob.Value())
+
+	bv.Set("a")
+
+	err = g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-3", ob.Value())
+
+	err = g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-3", ob.Value())
+
+	testutil.Equal(t, 3, updates)
+}

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -42,3 +42,39 @@ func Test_Sentinel(t *testing.T) {
 
 	testutil.Equal(t, 3, updates)
 }
+
+func Test_Sentinel_Unwatch(t *testing.T) {
+	ctx := testContext()
+	g := New()
+	v := Var(g, "foo")
+	var updates int
+	m := Map(g, v, func(vv string) string {
+		updates++
+		return vv + fmt.Sprintf("-mapped-%d", updates)
+	})
+	s := Sentinel(g, func() bool {
+		return updates < 3
+	}, m)
+
+	testutil.NotNil(t, s)
+
+	om := MustObserve(g, m)
+
+	err := g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-1", om.Value())
+
+	err = g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-2", om.Value())
+
+	testutil.Equal(t, 2, updates)
+
+	s.Unwatch(ctx)
+
+	err = g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-2", om.Value())
+
+	testutil.Equal(t, 2, updates)
+}

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -17,8 +17,7 @@ func Test_Sentinel(t *testing.T) {
 		return vv + fmt.Sprintf("-mapped-%d", updates)
 	})
 	s := Sentinel(g, func() bool {
-		fmt.Println("evaluating sentinel")
-		return updates < 2
+		return updates < 3
 	}, m)
 
 	testutil.NotNil(t, s)
@@ -35,5 +34,11 @@ func Test_Sentinel(t *testing.T) {
 
 	err = g.Stabilize(ctx)
 	testutil.NoError(t, err)
-	testutil.Equal(t, "foo-mapped-2", om.Value())
+	testutil.Equal(t, "foo-mapped-3", om.Value())
+
+	err = g.Stabilize(ctx)
+	testutil.NoError(t, err)
+	testutil.Equal(t, "foo-mapped-3", om.Value())
+
+	testutil.Equal(t, 3, updates)
 }


### PR DESCRIPTION
The goal with this node type is to create an easier to use version of the `Always` and `Cutoff` node combined.

It works by creating a special "parent" node type that isn't a traditional input, but is linked as one. 

There are potentially implications for this with necessary => unnecessary => necessary cycles with binds, and potentially will need to be addressed.