### PR TITLE
Optimize stabilization for large graphs

### DIFF
--- a/expert_graph.go
+++ b/expert_graph.go
@@ -109,8 +109,8 @@ func (eg *expertGraph) RecomputeHeapIDs() []Identifier {
 	output := make([]Identifier, 0, eg.graph.recomputeHeap.numItems)
 	for _, height := range eg.graph.recomputeHeap.heights {
 		if height != nil {
-			for key := range height.items {
-				output = append(output, key)
+			for v := height.head; v != nil; v = v.Node().nextInRecomputeHeap {
+				output = append(output, v.Node().id)
 			}
 		}
 	}

--- a/graph.go
+++ b/graph.go
@@ -709,22 +709,32 @@ func (graph *Graph) recompute(ctx context.Context, n INode, parallel bool) (err 
 	if parallel {
 		graph.recomputeHeap.mu.Lock()
 		for _, c := range nn.children {
-			isNecessary := c.Node().isNecessary()
-			isStale := c.Node().isStale()
-			isNotInRecomputeHeap := c.Node().heightInRecomputeHeap == HeightUnset
-			if isNecessary && isStale && isNotInRecomputeHeap {
-				graph.recomputeHeap.addNodeUnsafe(c)
+			// Don't add to the heap if it's already been added
+			if !(c.Node().heightInRecomputeHeap == HeightUnset) {
+				continue
 			}
+			if !c.Node().isNecessary() {
+				continue
+			}
+			if !c.Node().isStale() {
+				continue
+			}
+			graph.recomputeHeap.addNodeUnsafe(c)
 		}
 		graph.recomputeHeap.mu.Unlock()
 	} else {
 		for _, c := range nn.children {
-			isNecessary := c.Node().isNecessary()
-			isStale := c.Node().isStale()
-			isNotInRecomputeHeap := c.Node().heightInRecomputeHeap == HeightUnset
-			if isNecessary && isStale && isNotInRecomputeHeap {
-				graph.recomputeHeap.addNodeUnsafe(c)
+			// Don't add to the heap if it's already been added
+			if !(c.Node().heightInRecomputeHeap == HeightUnset) {
+				continue
 			}
+			if !c.Node().isNecessary() {
+				continue
+			}
+			if !c.Node().isStale() {
+				continue
+			}
+			graph.recomputeHeap.addNodeUnsafe(c)
 		}
 	}
 

--- a/recompute_heap.go
+++ b/recompute_heap.go
@@ -95,15 +95,14 @@ func (rh *recomputeHeap) removeMinHeightIter(iter *recomputeHeapListIter) {
 	var heightBlock *recomputeHeapList
 	for x := 0; x < len(rh.heights); x++ {
 		heightBlock = rh.heights[x]
-		if heightBlock != nil && heightBlock.len() > 0 {
+		if !heightBlock.isEmpty() {
 			break
 		}
 	}
 	iter.cursor = heightBlock.head
+	rh.numItems = rh.numItems - heightBlock.len()
 	heightBlock.head = nil
 	heightBlock.tail = nil
-	rh.numItems = rh.numItems - len(heightBlock.items)
-	clear(heightBlock.items)
 	rh.minHeight = rh.nextMinHeightUnsafe()
 }
 
@@ -119,11 +118,11 @@ func (rh *recomputeHeap) remove(node INode) {
 
 func (rh *recomputeHeap) removeMinUnsafe() (node INode, ok bool) {
 	for x := rh.minHeight; x <= rh.maxHeight; x++ {
-		if rh.heights[x] != nil && rh.heights[x].len() > 0 {
+		if !rh.heights[x].isEmpty() {
 			_, node, ok = rh.heights[x].pop()
 			rh.numItems--
 			node.Node().heightInRecomputeHeap = HeightUnset
-			if rh.heights[x].len() > 0 {
+			if !rh.heights[x].isEmpty() {
 				rh.minHeight = x
 			} else {
 				rh.minHeight = rh.nextMinHeightUnsafe()
@@ -152,7 +151,7 @@ func (rh *recomputeHeap) removeNodeUnsafe(item INode) {
 	id := item.Node().id
 	height := item.Node().heightInRecomputeHeap
 	rh.heights[height].remove(id)
-	isLastAtHeight := rh.heights[height].len() == 0
+	isLastAtHeight := rh.heights[height].isEmpty()
 	if height == rh.minHeight && isLastAtHeight {
 		rh.minHeight = rh.nextMinHeightUnsafe()
 	}
@@ -187,7 +186,7 @@ func (rh *recomputeHeap) nextMinHeightUnsafe() (next int) {
 		return
 	}
 	for x := 0; x < len(rh.heights); x++ {
-		if rh.heights[x] != nil && rh.heights[x].len() > 0 {
+		if !rh.heights[x].isEmpty() {
 			next = x
 			break
 		}
@@ -203,7 +202,7 @@ func (rh *recomputeHeap) fixUnsafe(n INode) {
 // sanityCheck loops through each item in each height block
 // and checks that all the height values match.
 func (rh *recomputeHeap) sanityCheck() error {
-	if rh.numItems > 0 && (rh.heights[rh.minHeight] == nil || rh.heights[rh.minHeight].len() == 0) {
+	if rh.numItems > 0 && (rh.heights[rh.minHeight].isEmpty()) {
 		return fmt.Errorf("recompute heap; sanity check; lookup has items but min height block is empty")
 	}
 	for heightIndex, height := range rh.heights {

--- a/recompute_heap.go
+++ b/recompute_heap.go
@@ -119,7 +119,7 @@ func (rh *recomputeHeap) remove(node INode) {
 func (rh *recomputeHeap) removeMinUnsafe() (node INode, ok bool) {
 	for x := rh.minHeight; x <= rh.maxHeight; x++ {
 		if !rh.heights[x].isEmpty() {
-			_, node, ok = rh.heights[x].pop()
+			node, ok = rh.heights[x].pop()
 			rh.numItems--
 			node.Node().heightInRecomputeHeap = HeightUnset
 			if !rh.heights[x].isEmpty() {

--- a/recompute_heap_list.go
+++ b/recompute_heap_list.go
@@ -45,12 +45,11 @@ func (l *recomputeHeapList) push(v INode) {
 	l.tail = v
 }
 
-func (l *recomputeHeapList) pop() (k Identifier, v INode, ok bool) {
+func (l *recomputeHeapList) pop() (v INode, ok bool) {
 	if l.head == nil {
 		return
 	}
 
-	k = l.head.Node().id
 	v = l.head
 	ok = true
 

--- a/recompute_heap_list_test.go
+++ b/recompute_heap_list_test.go
@@ -36,15 +36,13 @@ func Test_recomputeHeapList_push_pop(t *testing.T) {
 	n2 := newHeightIncr(g, 0)
 	n3 := newHeightIncr(g, 0)
 
-	var zeroID Identifier
-	id, n, ok := q.pop()
+	n, ok := q.pop()
 
 	// Region: empty list
 	{
 		testutil.Equal(t, false, ok)
 		testutil.Nil(t, q.head)
 		testutil.Nil(t, q.tail)
-		testutil.Equal(t, zeroID, id)
 		testutil.Nil(t, n)
 		testutil.Equal(t, 0, q.len())
 
@@ -163,9 +161,8 @@ func Test_recomputeHeapList_push_pop(t *testing.T) {
 
 	// Region: pop 0
 	{
-		id, n, ok = q.pop()
+		n, ok = q.pop()
 		testutil.Equal(t, true, ok)
-		testutil.Equal(t, n0.n.id, id)
 		testutil.Equal(t, n0.n.id, n.Node().id)
 		testutil.NotNil(t, q.head)
 		testutil.NotNil(t, rhnext(q.head))
@@ -188,9 +185,8 @@ func Test_recomputeHeapList_push_pop(t *testing.T) {
 
 	// Region: pop 1
 	{
-		id, n, ok = q.pop()
+		n, ok = q.pop()
 		testutil.Equal(t, true, ok)
-		testutil.Equal(t, n1.n.id, id)
 		testutil.Equal(t, n1.n.id, n.Node().id)
 		testutil.NotNil(t, q.head)
 		testutil.NotNil(t, rhnext(q.head))
@@ -215,9 +211,8 @@ func Test_recomputeHeapList_push_pop(t *testing.T) {
 
 	// Region: pop 2
 	{
-		id, n, ok = q.pop()
+		n, ok = q.pop()
 		testutil.Equal(t, true, ok)
-		testutil.Equal(t, n2.n.id, id)
 		testutil.Equal(t, n2.n.id, n.Node().id)
 		testutil.NotNil(t, q.head)
 		testutil.Nil(t, rhnext(q.head))
@@ -238,9 +233,8 @@ func Test_recomputeHeapList_push_pop(t *testing.T) {
 
 	// Region: pop 3
 	{
-		id, n, ok = q.pop()
+		n, ok = q.pop()
 		testutil.Equal(t, true, ok)
-		testutil.Equal(t, n3.n.id, id)
 		testutil.Equal(t, n3.n.id, n.Node().id)
 		testutil.Nil(t, q.head)
 		testutil.Nil(t, q.tail)
@@ -257,10 +251,9 @@ func Test_recomputeHeapList_push_pop(t *testing.T) {
 
 	// Region: pop empty
 	{
-		id, n, ok = q.pop()
+		n, ok = q.pop()
 		testutil.Equal(t, false, ok)
 		testutil.Nil(t, n)
-		testutil.Equal(t, zeroID, id)
 
 		testutil.Equal(t, false, q.has(n0.Node().id))
 		testutil.Equal(t, false, q.has(n1.Node().id))


### PR DESCRIPTION
I noticed that the stabilization was actually only spending a small amount of its time doing the actual computation; here's a flame graph before this series:

<img width="1583" alt="Screenshot 2024-04-16 at 4 54 38 PM" src="https://github.com/wcharczuk/go-incr/assets/1247773/ffe5353c-f421-4414-85a6-6302ad3c7d67">

I spent some time looking at some low-hanging fruit; the result is after this series:

<img width="1583" alt="Screenshot 2024-04-16 at 4 55 28 PM" src="https://github.com/wcharczuk/go-incr/assets/1247773/b06f4a12-24d4-41b0-bdda-9fae049df85a">

After these changes, it's hard to see how to optimize things outside of `maybeStabilize` any further.  `recompute` is basically just doing loops and calling functions, none of which can be optimized away; `isStateInRespectToParent` is just ranging over a single slice and following two pointers; `pop` is just moving some pointers around.